### PR TITLE
chore: update lucide-react to v0.553.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "notionic",
@@ -7,7 +8,7 @@
         "feed": "^5.1.0",
         "framer-motion": "^12.23.24",
         "got": "^14.6.0",
-        "lucide-react": "^0.546.0",
+        "lucide-react": "^0.553.0",
         "next": "16.0.0",
         "next-themes": "^0.4.6",
         "notion-client": "^7.7.1",
@@ -26,7 +27,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.5",
         "@eslint/eslintrc": "^3.3.1",
-        "@next/bundle-analyzer": "15.5.5",
+        "@next/bundle-analyzer": "^15.5.5",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -39,7 +40,7 @@
         "@vitest/ui": "^4.0.8",
         "autoprefixer": "^10.4.21",
         "eslint": "^9.39.1",
-        "eslint-config-next": "15.5.6",
+        "eslint-config-next": "^15.5.6",
         "happy-dom": "^20.0.4",
         "lefthook": "^2.0.4",
         "next-sitemap": "^4.2.3",
@@ -964,7 +965,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@0.546.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ=="],
+    "lucide-react": ["lucide-react@0.553.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "feed": "^5.1.0",
     "framer-motion": "^12.23.24",
     "got": "^14.6.0",
-    "lucide-react": "^0.546.0",
+    "lucide-react": "^0.553.0",
     "next": "16.0.0",
     "next-themes": "^0.4.6",
     "notion-client": "^7.7.1",


### PR DESCRIPTION
Update lucide-react from 0.546.0 to 0.553.0
- All type checks pass
- All tests pass (170/170)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * lucide-reactライブラリの依存関係バージョンを最新版に更新しました。これにより、互換性が向上し、より安定したパフォーマンスが実現されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->